### PR TITLE
🐛 配列の値指定ミスを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# twitter-search
+## introduction
+
+Twitterを検索して画像や文字を取得する.  
+Brefを使って、AWS上で動かすことができる.
+
+## install
+
+```
+make init
+```
+
+## test :rotating_light:
+```
+make test
+```
+
+## deploy :package:
+```
+make init
+```

--- a/init.sh
+++ b/init.sh
@@ -12,12 +12,12 @@ echo "シークレットアクセスキーを指定してください"
 echo -n 'aws_secret_access_key: '
 read aws_secret_access_key
 
-if [[ -n "${aws_access_key_id}" ]];then
+if [[ -z "${aws_access_key_id}" ]];then
   echo 'アクセスキーが指定されてません'
   exit 1
 fi
 
-if [[ -n "${aws_secret_access_key}" ]];then
+if [[ -z "${aws_secret_access_key}" ]];then
   echo 'シークレットアクセスキーが指定されてません'
   exit 1
 fi

--- a/src/TwitterImgSearch.php
+++ b/src/TwitterImgSearch.php
@@ -53,7 +53,8 @@ class TwitterImgSearch
             }
         }
 
-        $imageUrl = $imageList[rand(0, (count($imageList)))];
+        $maxCount = (count($imageList) - 1);
+        $imageUrl = $imageList[rand(0, $maxCount)];
 
         $this->logger->info("imageList", $imageList);
 
@@ -70,6 +71,7 @@ class TwitterImgSearch
     private function getTwitterSearchWord() : string
     {
         $list = explode(',', getenv('TWITTER_SEARCH_IMG'));
-        return $list[rand(0, (count($list) - 1))];
+        $maxCount = (count($list) - 1);
+        return $list[rand(0, $maxCount)];
     }
 }


### PR DESCRIPTION
### 概要
配列の値指定ミスを修正.
配列の添字は0から始まるので、最大値から1を引く必要がある.

### 備考
* シェルの空文字判定を修正
空かどうか判定する場合はzが正解だった.
https://hacknote.jp/archives/32292/
* 📚 READMEを作成 